### PR TITLE
feat!: arbitrary command execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -134,12 +134,9 @@ checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -149,9 +146,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -162,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -172,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -302,9 +299,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "eyre"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6267a1fa6f59179ea4afc8e50fd8612a3cc60bc858f786ff877a4a8cb042799"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
@@ -353,9 +350,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -411,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -445,9 +442,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -460,15 +457,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -478,9 +475,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -504,14 +501,13 @@ dependencies = [
  "clap",
  "color-eyre",
  "ctrlc",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "nix",
  "owo-colors 4.0.0",
  "serde",
  "serde_json",
  "serde_with",
  "shlex",
- "smartstring",
  "strsim 0.11.0",
 ]
 
@@ -598,9 +594,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "serde"
@@ -643,7 +639,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -679,24 +675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "serde",
- "static_assertions",
- "version_check",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -731,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -843,9 +821,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -853,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -868,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -878,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -891,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "windows-core"
@@ -915,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -930,45 +908,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,17 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 serde_with = { version = "3.6.1", features = ["indexmap_2"] }
 shlex = "1.3.0"
-smartstring = { version = "1.0.1", features = ["serde"] }
 strsim = "0.11.0"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+
+redundant_closure_for_method_calls = "allow"
+module_name_repetitions = "allow"
+missing_panics_doc = "allow"
+missing_errors_doc = "allow"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,0 @@
-[[disallowed-types]]
-path = "std::string::String"
-reason = "prefer `smartstring::alias::String` over `std::string::String` if possible"

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@
   self,
   lto ? true,
   optimizeSize ? true,
+  nrxAlias ? true,
 }: let
   filter = path: type: let
     path' = toString path;
@@ -49,8 +50,12 @@ in
       pkg-config
     ];
 
+    postInstall = ''
+      ${lib.optionalString nrxAlias "ln -s $out/bin/nrr $out/bin/nrx"}
+    '';
+
     meta = with lib; {
-      description = "Minimal, blazing fast Node.js script runner";
+      description = "Minimal, blazing fast npm scripts runner";
       maintainers = with maintainers; [ryanccn];
       license = licenses.gpl3Only;
       mainProgram = "nrr";

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708692673,
-        "narHash": "sha256-qIQMXkkp3/Lo2Zu41BK/oN3Dt3b5rUJELvt+CbAXPXw=",
+        "lastModified": 1709780214,
+        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48b75eb6e521f2303cb3cd53a94ec80021b422aa",
+        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Minimal, blazing fast Node.js script runner";
+  description = "Minimal, blazing fast npm scripts runner";
 
   nixConfig = {
     extra-substituters = ["https://cache.garnix.io"];

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -17,10 +17,13 @@ pub fn handle(package_paths: impl Iterator<Item = PathBuf>, args: &ExecArgs) -> 
                 if has_exec(&package_path, &args.bin) {
                     eprint!(
                         "{}",
-                        package.make_prefix(match crate::get_level() {
-                            1 => None,
-                            _ => Some(&args.bin),
-                        })
+                        package.make_prefix(
+                            match crate::get_level() {
+                                1 => None,
+                                _ => Some(&args.bin),
+                            },
+                            Stream::Stderr
+                        )
                     );
 
                     run_exec(&package_path, &package, &args.bin, &args.extra_args)?;

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,0 +1,47 @@
+use color_eyre::eyre::Result;
+use owo_colors::{OwoColorize, Stream};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::package_json::PackageJson;
+use crate::run::{has_exec, run_exec};
+
+use super::ExecArgs;
+
+pub fn handle(package_paths: impl Iterator<Item = PathBuf>, args: &ExecArgs) -> Result<()> {
+    let mut executed_exec = false;
+
+    for package_path in package_paths {
+        if let Ok(raw) = fs::read_to_string(&package_path) {
+            if let Ok(package) = serde_json::from_str::<PackageJson>(&raw) {
+                if has_exec(&package_path, &args.bin) {
+                    eprint!(
+                        "{}",
+                        package.make_prefix(match crate::get_level() {
+                            1 => None,
+                            _ => Some(&args.bin),
+                        })
+                    );
+
+                    run_exec(&package_path, &package, &args.bin, &args.extra_args)?;
+
+                    executed_exec = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if !executed_exec {
+        eprintln!(
+            "{}  No binary found with name {}.",
+            "error".if_supports_color(Stream::Stderr, |text| text.red()),
+            args.bin
+                .if_supports_color(Stream::Stderr, |text| text.bold()),
+        );
+
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -10,7 +10,7 @@ pub fn handle(package_paths: impl Iterator<Item = PathBuf>) -> Result<bool> {
     for package in package_paths {
         let raw = fs::read_to_string(package)?;
         if let Ok(package_data) = serde_json::from_str::<PackageJson>(&raw) {
-            print!("{}", package_data.make_prefix(None));
+            print!("{}", package_data.make_prefix(None, Stream::Stdout));
 
             found_package = true;
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,0 +1,30 @@
+use color_eyre::eyre::Result;
+use owo_colors::{OwoColorize, Stream};
+
+use crate::package_json::PackageJson;
+use std::{fs, path::PathBuf};
+
+pub fn handle(package_paths: impl Iterator<Item = PathBuf>) -> Result<bool> {
+    let mut found_package = false;
+
+    for package in package_paths {
+        let raw = fs::read_to_string(package)?;
+        if let Ok(package_data) = serde_json::from_str::<PackageJson>(&raw) {
+            print!("{}", package_data.make_prefix(None));
+
+            found_package = true;
+
+            for (script_name, script_content) in &package_data.scripts {
+                println!(
+                    "{}",
+                    script_name.if_supports_color(Stream::Stdout, |text| text.cyan())
+                );
+                println!("  {script_content}");
+            }
+
+            println!();
+        }
+    }
+
+    Ok(found_package)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,155 @@
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use color_eyre::Result;
+use owo_colors::{OwoColorize, Stream};
+
+use std::{env, sync::OnceLock};
+
+mod exec;
+mod list;
+mod run;
+
+/// Minimal, blazing fast npm scripts runner.
+#[derive(Parser, Clone)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[clap(flatten)]
+    root_args: RootArgs,
+
+    #[clap(subcommand)]
+    subcommand: Option<Subcommands>,
+}
+
+#[derive(Parser, Clone)]
+#[command(author, version, about, long_about = None)]
+pub struct NrxCli {
+    #[clap(flatten)]
+    args: ExecArgs,
+}
+
+#[derive(Subcommand, Clone)]
+#[command(args_conflicts_with_subcommands = true)]
+enum Subcommands {
+    /// Run a script
+    #[clap(visible_alias = "run-script")]
+    Run(RunArgs),
+
+    /// Execute a command
+    #[clap(visible_alias = "x")]
+    Exec(ExecArgs),
+
+    /// List available scripts
+    #[clap(visible_alias = "ls")]
+    List,
+}
+
+#[derive(Args, Clone)]
+struct RootArgs {
+    /// The name of the script
+    script: Option<String>,
+
+    /// Extra arguments to pass to the script
+    #[clap(allow_hyphen_values = true)]
+    extra_args: Vec<String>,
+
+    /// Don't run pre- and post- scripts
+    #[arg(short, long)]
+    no_pre_post: bool,
+}
+
+#[derive(Args, Clone)]
+struct RunArgs {
+    /// The name of the script
+    script: String,
+
+    /// Extra arguments to pass to the script
+    #[clap(allow_hyphen_values = true)]
+    extra_args: Vec<String>,
+
+    /// Don't run pre- and post- scripts
+    #[arg(short, long)]
+    no_pre_post: bool,
+}
+
+#[derive(Args, Clone)]
+struct ExecArgs {
+    /// The name of the command
+    bin: String,
+
+    /// Extra arguments to pass to the command
+    #[clap(allow_hyphen_values = true)]
+    extra_args: Vec<String>,
+}
+
+pub fn get_level() -> &'static usize {
+    static ONCE_LOCK: OnceLock<usize> = OnceLock::new();
+    ONCE_LOCK.get_or_init(|| {
+        std::env::var("NRR_LEVEL")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(1)
+    })
+}
+
+impl Cli {
+    pub fn execute(&self) -> Result<()> {
+        let current_dir = env::current_dir()?;
+        let package_paths = current_dir
+            .ancestors()
+            .map(|p| p.join("package.json"))
+            .filter(|p| p.is_file());
+
+        match &self.subcommand {
+            Some(Subcommands::Run(args)) => {
+                run::handle(package_paths, args)?;
+            }
+
+            Some(Subcommands::Exec(args)) => {
+                exec::handle(package_paths, args)?;
+            }
+
+            Some(Subcommands::List) => {
+                let found_package = list::handle(package_paths)?;
+                if !found_package {
+                    eprintln!(
+                        "{}  No packages found!",
+                        "error".if_supports_color(Stream::Stderr, |text| text.red()),
+                    );
+                }
+            }
+
+            None => {
+                if let Some(script_name) = &self.root_args.script {
+                    run::handle(
+                        package_paths,
+                        &RunArgs {
+                            script: script_name.to_owned(),
+                            extra_args: self.root_args.extra_args.clone(),
+                            no_pre_post: self.root_args.no_pre_post,
+                        },
+                    )?;
+                } else {
+                    let found_package = list::handle(package_paths)?;
+                    if !found_package {
+                        Cli::command().print_help()?;
+                    }
+                }
+            }
+        };
+
+        Ok(())
+    }
+}
+
+impl NrxCli {
+    pub fn execute(&self) -> Result<()> {
+        let current_dir = env::current_dir()?;
+        let package_paths = current_dir
+            .ancestors()
+            .map(|p| p.join("package.json"))
+            .filter(|p| p.is_file());
+
+        exec::handle(package_paths, &self.args)?;
+
+        Ok(())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -83,7 +83,7 @@ struct ExecArgs {
 pub fn get_level() -> &'static usize {
     static ONCE_LOCK: OnceLock<usize> = OnceLock::new();
     ONCE_LOCK.get_or_init(|| {
-        std::env::var("NRR_LEVEL")
+        std::env::var("__NRR_LEVEL")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(1)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -19,10 +19,13 @@ fn run_script_full(
 ) -> Result<()> {
     eprint!(
         "{}",
-        package_data.make_prefix(match crate::get_level() {
-            1 => None,
-            _ => Some(script_name),
-        })
+        package_data.make_prefix(
+            match crate::get_level() {
+                1 => None,
+                _ => Some(script_name),
+            },
+            Stream::Stderr
+        )
     );
 
     if !no_pre_post {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,0 +1,125 @@
+use color_eyre::eyre::Result;
+use owo_colors::{OwoColorize, Stream};
+use std::path::PathBuf;
+use std::{fs, path::Path};
+
+use crate::package_json::{PackageJson, PackageJsonOwned};
+use crate::run::{run_script, ScriptType};
+use crate::suggest::suggest;
+
+use super::RunArgs;
+
+fn run_script_full(
+    package: &Path,
+    package_data: &PackageJson<'_, '_, '_>,
+    script_name: &str,
+    script_cmd: &str,
+    extra_args: &[String],
+    no_pre_post: bool,
+) -> Result<()> {
+    eprint!(
+        "{}",
+        package_data.make_prefix(match crate::get_level() {
+            1 => None,
+            _ => Some(script_name),
+        })
+    );
+
+    if !no_pre_post {
+        let pre_script_name = String::from("pre") + script_name;
+
+        if let Some(pre_script_cmd) = package_data.scripts.get(&pre_script_name) {
+            run_script(
+                package,
+                package_data,
+                &pre_script_name,
+                pre_script_cmd,
+                ScriptType::Pre,
+                &[],
+            )?;
+        }
+    }
+
+    run_script(
+        package,
+        package_data,
+        script_name,
+        script_cmd,
+        ScriptType::Normal,
+        extra_args,
+    )?;
+
+    if !no_pre_post {
+        let post_script_name = String::from("post") + script_name;
+
+        if let Some(post_script_cmd) = package_data.scripts.get(&post_script_name) {
+            run_script(
+                package,
+                package_data,
+                &post_script_name,
+                post_script_cmd,
+                ScriptType::Post,
+                &[],
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn handle(package_paths: impl Iterator<Item = PathBuf>, args: &RunArgs) -> Result<()> {
+    let mut resolved_packages = Vec::<PackageJsonOwned>::new();
+    let mut executed_script = false;
+
+    for package_path in package_paths {
+        if let Ok(raw) = fs::read_to_string(&package_path) {
+            if let Ok(package) = serde_json::from_str::<PackageJson>(&raw) {
+                if let Some(script_cmd) = package.scripts.get(&args.script) {
+                    run_script_full(
+                        &package_path,
+                        &package,
+                        &args.script,
+                        script_cmd,
+                        &args.extra_args,
+                        args.no_pre_post,
+                    )?;
+
+                    executed_script = true;
+                    break;
+                }
+
+                resolved_packages.push(package.to_owned(package_path));
+            }
+        }
+    }
+
+    if !executed_script {
+        eprintln!(
+            "{}  No script found with name {}.",
+            "error".if_supports_color(Stream::Stderr, |text| text.red()),
+            &args
+                .script
+                .if_supports_color(Stream::Stderr, |text| text.bold()),
+        );
+
+        for resolved_package in &resolved_packages {
+            if let Some(alternative) = suggest(&args.script, resolved_package) {
+                eprintln!(
+                    "       {} {}{}{}",
+                    "Did you mean".if_supports_color(Stream::Stderr, |text| text.dimmed()),
+                    "`".if_supports_color(Stream::Stderr, |text| text.dimmed()),
+                    format!("nrr {alternative}")
+                        .if_supports_color(Stream::Stderr, |text| text.cyan())
+                        .if_supports_color(Stream::Stderr, |text| text.dimmed()),
+                    "`?".if_supports_color(Stream::Stderr, |text| text.dimmed())
+                );
+
+                break;
+            }
+        }
+
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,208 +1,27 @@
-#![warn(clippy::all, clippy::pedantic, clippy::perf)]
-#![allow(
-    clippy::redundant_closure_for_method_calls,
-    clippy::module_name_repetitions
-)]
-#![forbid(unsafe_code)]
+pub mod cli;
+pub mod package_json;
+pub mod run;
+pub mod suggest;
 
-use clap::{CommandFactory, Parser};
-use color_eyre::Result;
-use owo_colors::{OwoColorize, Stream};
+use std::env;
 
-use package_json::PackageJsonOwned;
-use smartstring::alias::String;
-use std::{env, fs, path::Path, sync::OnceLock};
+pub use cli::get_level;
 
-mod package_json;
-mod run_script;
-mod suggest;
+use crate::cli::{Cli, NrxCli};
+use clap::Parser as _;
 
-use crate::package_json::PackageJson;
-use crate::run_script::{run_script, ScriptType};
-
-#[derive(Parser)]
-#[command(author, version, about, long_about = None)]
-/// Minimal, blazing fast Node.js script runner
-struct Cli {
-    /// The name of the script
-    script: Option<String>,
-
-    /// Extra arguments to pass to the script
-    #[clap(allow_hyphen_values = true)]
-    extra_args: Option<Vec<String>>,
-
-    /// Run pre- and post- scripts
-    #[arg(short, long)]
-    pre_post: bool,
-}
-
-fn get_level() -> &'static usize {
-    static ONCE_LOCK: OnceLock<usize> = OnceLock::new();
-    ONCE_LOCK.get_or_init(|| {
-        std::env::var("NRR_LEVEL")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(1)
-    })
-}
-
-impl Cli {
-    fn run_script_full(
-        &self,
-        script_name: &str,
-        script_cmd: &str,
-        package: &Path,
-        package_data: &PackageJson<'_, '_, '_>,
-    ) -> Result<()> {
-        eprint!(
-            "{}",
-            package_data.make_prefix(match get_level() {
-                1 => None,
-                _ => Some(script_name),
-            })
-        );
-
-        if self.pre_post {
-            let pre_script_name = String::from("pre") + script_name;
-
-            if let Some(pre_script_cmd) = package_data.scripts.get(&pre_script_name) {
-                run_script(
-                    package,
-                    package_data,
-                    &pre_script_name,
-                    pre_script_cmd,
-                    ScriptType::Pre,
-                    None,
-                )?;
-            }
-        }
-
-        run_script(
-            package,
-            package_data,
-            script_name,
-            script_cmd,
-            ScriptType::Normal,
-            self.extra_args.as_ref(),
-        )?;
-
-        if self.pre_post {
-            let post_script_name = String::from("post") + script_name;
-
-            if let Some(post_script_cmd) = package_data.scripts.get(&post_script_name) {
-                run_script(
-                    package,
-                    package_data,
-                    &post_script_name,
-                    post_script_cmd,
-                    ScriptType::Post,
-                    None,
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn execute(&self) -> Result<()> {
-        let current_dir = env::current_dir()?;
-        let package_paths = current_dir
-            .ancestors()
-            .map(|p| p.join("package.json"))
-            .filter(|p| p.is_file());
-
-        let mut resolved_packages = Vec::<PackageJsonOwned>::new();
-
-        if let Some(script_name) = &self.script {
-            let mut executed_script = false;
-
-            for package_path in package_paths {
-                if let Ok(raw) = fs::read_to_string(&package_path) {
-                    if let Ok(package) = serde_json::from_str::<PackageJson>(&raw) {
-                        if let Some(script_cmd) = package.scripts.get(script_name) {
-                            self.run_script_full(script_name, script_cmd, &package_path, &package)?;
-
-                            executed_script = true;
-                            break;
-                        }
-
-                        resolved_packages.push(package.to_owned());
-                    }
-                }
-            }
-
-            if !executed_script {
-                eprintln!(
-                    "{}  No script found with name {}.",
-                    "error".if_supports_color(Stream::Stderr, |text| text.red()),
-                    script_name.if_supports_color(Stream::Stderr, |text| text.bold()),
-                );
-
-                for resolved_package in &resolved_packages {
-                    if let Some(alternative) = suggest::suggest(script_name, resolved_package) {
-                        eprintln!(
-                            "       {} {}{}{}",
-                            "Did you mean".if_supports_color(Stream::Stderr, |text| text.dimmed()),
-                            "`".if_supports_color(Stream::Stderr, |text| text.dimmed()),
-                            format!("nrr {alternative}")
-                                .if_supports_color(Stream::Stderr, |text| text.cyan())
-                                .if_supports_color(Stream::Stderr, |text| text.dimmed()),
-                            "`?".if_supports_color(Stream::Stderr, |text| text.dimmed())
-                        );
-
-                        break;
-                    }
-                }
-
-                std::process::exit(1);
-            }
-        } else {
-            let mut found_package = false;
-
-            for package in package_paths {
-                let raw = fs::read_to_string(package)?;
-                if let Ok(package_data) = serde_json::from_str::<PackageJson>(&raw) {
-                    print!("{}", package_data.make_prefix(None));
-
-                    found_package = true;
-
-                    for (script_name, script_content) in &package_data.scripts {
-                        println!(
-                            "{}",
-                            script_name.if_supports_color(Stream::Stdout, |text| text.cyan())
-                        );
-                        println!("  {script_content}");
-                    }
-
-                    println!();
-                }
-            }
-
-            if !found_package {
-                Cli::command().print_help()?;
-            }
-        };
-
-        Ok(())
-    }
-}
+use color_eyre::eyre::Result;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    #[allow(clippy::disallowed_types)]
-    let mut raw_args: Vec<std::string::String> = env::args().collect();
-
-    if env::var_os("NRR_COMPAT_MODE").is_some_and(|v| !v.is_empty())
-        && raw_args
-            .get(1)
-            .is_some_and(|v| v == "run" || v == "run-script")
-    {
-        raw_args.remove(1);
+    if env::current_exe().is_ok_and(|exe| exe.file_name().is_some_and(|f| f == "nrx")) {
+        let cli = NrxCli::parse();
+        cli.execute()?;
+    } else {
+        let cli = Cli::parse();
+        cli.execute()?;
     }
-
-    let cli = Cli::parse_from(raw_args);
-    cli.execute()?;
 
     Ok(())
 }

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -33,6 +33,7 @@ fn make_prefix_internal(
     name: Option<impl Into<String>>,
     version: Option<impl Into<String>>,
     script: Option<impl Into<String>>,
+    stream: Stream,
 ) -> String {
     let mut prefix = String::new();
 
@@ -40,7 +41,7 @@ fn make_prefix_internal(
         prefix.push_str(
             &name
                 .into()
-                .if_supports_color(Stream::Stderr, |text| text.magenta())
+                .if_supports_color(stream, |text| text.magenta())
                 .to_string(),
         );
 
@@ -50,8 +51,8 @@ fn make_prefix_internal(
             version_str.push_str(&version.into());
             prefix.push_str(
                 &version_str
-                    .if_supports_color(Stream::Stderr, |text| text.magenta())
-                    .if_supports_color(Stream::Stderr, |text| text.dimmed())
+                    .if_supports_color(stream, |text| text.magenta())
+                    .if_supports_color(stream, |text| text.dimmed())
                     .to_string(),
             );
         }
@@ -90,11 +91,12 @@ impl PackageJson<'_, '_, '_> {
 
     #[allow(dead_code)]
     #[must_use]
-    pub fn make_prefix(&self, script_name: Option<&str>) -> String {
+    pub fn make_prefix(&self, script_name: Option<&str>, stream: Stream) -> String {
         make_prefix_internal(
             self.name.as_ref().map(|v| v.as_ref()),
             self.version.as_ref().map(|v| v.as_ref()),
             script_name,
+            stream,
         )
     }
 }
@@ -102,7 +104,12 @@ impl PackageJson<'_, '_, '_> {
 impl PackageJsonOwned {
     #[allow(dead_code)]
     #[must_use]
-    pub fn make_prefix(&self, script_name: Option<&str>) -> String {
-        make_prefix_internal(self.name.as_ref(), self.version.as_ref(), script_name)
+    pub fn make_prefix(&self, script_name: Option<&str>, stream: Stream) -> String {
+        make_prefix_internal(
+            self.name.as_ref(),
+            self.version.as_ref(),
+            script_name,
+            stream,
+        )
     }
 }

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -3,8 +3,7 @@ use serde::Deserialize;
 use serde_with::{serde_as, BorrowCow};
 
 use indexmap::IndexMap;
-use smartstring::alias::String;
-use std::borrow::Cow;
+use std::{borrow::Cow, path::PathBuf};
 
 pub type AIndexMap<K, V> = IndexMap<K, V, ahash::RandomState>;
 
@@ -22,20 +21,62 @@ pub struct PackageJson<'a, 'b, 'c> {
     pub scripts: AIndexMap<String, Cow<'c, str>>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct PackageJsonOwned {
+    pub path: PathBuf,
     pub name: Option<String>,
     pub version: Option<String>,
-
-    #[serde(default)]
     pub scripts: AIndexMap<String, String>,
+}
+
+fn make_prefix_internal(
+    name: Option<impl Into<String>>,
+    version: Option<impl Into<String>>,
+    script: Option<impl Into<String>>,
+) -> String {
+    let mut prefix = String::new();
+
+    if let Some(name) = name {
+        prefix.push_str(
+            &name
+                .into()
+                .if_supports_color(Stream::Stderr, |text| text.magenta())
+                .to_string(),
+        );
+
+        if let Some(version) = version {
+            let mut version_str = String::new();
+            version_str.push('@');
+            version_str.push_str(&version.into());
+            prefix.push_str(
+                &version_str
+                    .if_supports_color(Stream::Stderr, |text| text.magenta())
+                    .if_supports_color(Stream::Stderr, |text| text.dimmed())
+                    .to_string(),
+            );
+        }
+
+        if let Some(script) = script {
+            prefix.push(' ');
+            prefix.push_str(
+                &script
+                    .into()
+                    .if_supports_color(Stream::Stderr, |text| text.cyan())
+                    .to_string(),
+            );
+        }
+
+        prefix.push('\n');
+    }
+
+    prefix
 }
 
 impl PackageJson<'_, '_, '_> {
     #[must_use]
-    pub fn to_owned(&self) -> PackageJsonOwned {
+    pub fn to_owned(&self, path: PathBuf) -> PackageJsonOwned {
         PackageJsonOwned {
+            path,
             name: self.name.clone().map(|v| v.into()),
             version: self.version.clone().map(|v| v.into()),
             scripts: self
@@ -47,41 +88,21 @@ impl PackageJson<'_, '_, '_> {
         }
     }
 
+    #[allow(dead_code)]
     #[must_use]
     pub fn make_prefix(&self, script_name: Option<&str>) -> String {
-        let mut prefix = String::new();
+        make_prefix_internal(
+            self.name.as_ref().map(|v| v.as_ref()),
+            self.version.as_ref().map(|v| v.as_ref()),
+            script_name,
+        )
+    }
+}
 
-        if let Some(name) = &self.name {
-            prefix.push_str(
-                &name
-                    .if_supports_color(Stream::Stderr, |text| text.magenta())
-                    .to_string(),
-            );
-
-            if let Some(version) = &self.version {
-                let mut version_str = String::new();
-                version_str.push('@');
-                version_str.push_str(version);
-                prefix.push_str(
-                    &version_str
-                        .if_supports_color(Stream::Stderr, |text| text.magenta())
-                        .if_supports_color(Stream::Stderr, |text| text.dimmed())
-                        .to_string(),
-                );
-            }
-
-            if let Some(script_name) = script_name {
-                prefix.push(' ');
-                prefix.push_str(
-                    &script_name
-                        .if_supports_color(Stream::Stderr, |text| text.cyan())
-                        .to_string(),
-                );
-            }
-
-            prefix.push('\n');
-        }
-
-        prefix
+impl PackageJsonOwned {
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn make_prefix(&self, script_name: Option<&str>) -> String {
+        make_prefix_internal(self.name.as_ref(), self.version.as_ref(), script_name)
     }
 }

--- a/src/run/exec.rs
+++ b/src/run/exec.rs
@@ -1,0 +1,84 @@
+#[cfg(unix)]
+use nix::{
+    sys::signal::{kill, Signal},
+    unistd::Pid,
+};
+
+use std::{env, path::Path, process::Command};
+
+use color_eyre::Result;
+use owo_colors::{OwoColorize, Stream};
+
+#[cfg(unix)]
+use ctrlc::set_handler;
+
+use crate::{package_json::PackageJson, run::util};
+
+pub fn run_exec(
+    package_path: &Path,
+    package_data: &PackageJson<'_, '_, '_>,
+    bin: &str,
+    args: &[String],
+) -> Result<()> {
+    let package_folder = package_path.parent().unwrap();
+
+    let cmd_prefix = "$".repeat(*crate::get_level());
+
+    eprintln!(
+        "{} {} {}",
+        cmd_prefix
+            .if_supports_color(Stream::Stderr, |text| text.cyan())
+            .if_supports_color(Stream::Stderr, |text| text.dimmed()),
+        bin.if_supports_color(Stream::Stderr, |text| text.dimmed()),
+        args.join(" ")
+            .if_supports_color(Stream::Stderr, |text| text.dimmed())
+    );
+
+    let mut subproc = Command::new(bin);
+    subproc.current_dir(package_folder);
+
+    subproc.args(args.iter().map(|f| f.to_string()));
+
+    subproc.env("PATH", util::make_patched_path(package_path)?);
+
+    subproc.env("NRR_LEVEL", format!("{}", crate::get_level() + 1));
+
+    subproc
+        .env("npm_execpath", env::current_exe()?)
+        .env("npm_package_json", package_path);
+
+    if let Some(name) = &package_data.name {
+        subproc.env("npm_package_name", name.as_ref());
+    }
+    if let Some(version) = &package_data.version {
+        subproc.env("npm_package_version", version.as_ref());
+    }
+
+    let mut child = subproc.spawn()?;
+
+    #[allow(clippy::cast_possible_wrap)]
+    #[cfg(unix)]
+    let pid = Pid::from_raw(child.id() as i32);
+
+    #[cfg(unix)]
+    set_handler(move || {
+        kill(pid, Signal::SIGINT).ok();
+    })?;
+
+    let status = child.wait()?;
+
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+
+        eprintln!(
+            "{}  Exited with status {}!",
+            "error".if_supports_color(Stream::Stderr, |text| text.red()),
+            code.to_string()
+                .if_supports_color(Stream::Stderr, |text| text.bold()),
+        );
+
+        std::process::exit(code);
+    }
+
+    Ok(())
+}

--- a/src/run/exec.rs
+++ b/src/run/exec.rs
@@ -41,7 +41,7 @@ pub fn run_exec(
 
     subproc.env("PATH", util::make_patched_path(package_path)?);
 
-    subproc.env("NRR_LEVEL", format!("{}", crate::get_level() + 1));
+    subproc.env("__NRR_LEVEL", format!("{}", crate::get_level() + 1));
 
     subproc
         .env("npm_execpath", env::current_exe()?)

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,0 +1,7 @@
+mod exec;
+mod script;
+mod util;
+
+pub use exec::run_exec;
+pub use script::{run_script, ScriptType};
+pub use util::has_exec;

--- a/src/run/script.rs
+++ b/src/run/script.rs
@@ -62,15 +62,15 @@ pub fn run_script(
 
     let mut full_cmd = script_cmd.to_owned();
 
-    if !extra_args.is_empty() {
-        full_cmd.push(' ');
-        extra_args
-            .iter()
-            .map(|f| shlex::try_quote(f))
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .for_each(|arg| full_cmd.push_str(arg.as_ref()));
-    }
+    extra_args
+        .iter()
+        .map(|f| shlex::try_quote(f))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .for_each(|arg| {
+            full_cmd.push(' ');
+            full_cmd.push_str(arg.as_ref());
+        });
 
     let cmd_prefix = script_type.prefix() + &"$".repeat(*crate::get_level());
 
@@ -87,7 +87,7 @@ pub fn run_script(
 
     subproc.env("PATH", make_patched_path(package_path)?);
 
-    subproc.env("NRR_LEVEL", format!("{}", crate::get_level() + 1));
+    subproc.env("__NRR_LEVEL", format!("{}", crate::get_level() + 1));
 
     subproc
         .env("npm_execpath", env::current_exe()?)

--- a/src/run/util.rs
+++ b/src/run/util.rs
@@ -1,0 +1,33 @@
+use color_eyre::eyre::Result;
+use std::{
+    env,
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+#[must_use]
+pub fn make_patched_paths(package_path: &Path) -> Vec<PathBuf> {
+    let mut patched_path = package_path
+        .ancestors()
+        .map(|p| p.join("node_modules").join(".bin"))
+        .filter(|p| p.is_dir())
+        .collect::<Vec<_>>();
+
+    if let Ok(existing_path) = env::var("PATH") {
+        patched_path.extend(env::split_paths(&existing_path));
+    }
+
+    patched_path
+}
+
+pub fn make_patched_path(package_path: &Path) -> Result<OsString> {
+    Ok(env::join_paths(make_patched_paths(package_path))?)
+}
+
+#[must_use]
+pub fn has_exec(package_path: &Path, bin: &str) -> bool {
+    make_patched_paths(package_path)
+        .into_iter()
+        .map(|p| p.join(bin))
+        .any(|p| p.is_file())
+}

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -1,8 +1,8 @@
 use crate::package_json::PackageJsonOwned;
 
-use smartstring::alias::String;
 use std::cmp::Ordering;
 
+#[must_use]
 pub fn suggest(input: &str, package: &PackageJsonOwned) -> Option<String> {
     let mut distances = package
         .scripts


### PR DESCRIPTION
This PR primarily adds the ability to **execute arbitrary commands** in npm package contexts with `nrr` using the subcommand `nrr exec/x` or the standalone command `nrx` (which automatically takes over when `nrr` is symlinked or hard linked to a path with the base name as `nrx`). In addition, various pieces of functionality were made available in separate subcommands (e.g. `nrr list` and `nrr run`) while retaining the root command's original functionality.

The `-p/--pre-post` flag has been removed in favor of `-n/--no-pre-post`, since it is a better default to run associated lifecycle scripts.
