### PR TITLE
feat(list): use `unicode-width` for alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "terminal_size",
  "thiserror",
  "trycmd",
+ "unicode-width",
 ]
 
 [[package]]
@@ -972,6 +973,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ simd-json     = "0.13.10"
 strsim        = "0.11.1"
 terminal_size = "0.3.0"
 thiserror     = "1.0.63"
+unicode-width = "0.1.13"
 
 [dev-dependencies]
 trycmd = "0.15.6"

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre::Result;
 use owo_colors::{OwoColorize as _, Stream};
 use terminal_size::terminal_size;
+use unicode_width::UnicodeWidthStr as _;
 
 use crate::package_json::PackageJson;
 use std::{
@@ -25,7 +26,7 @@ pub fn handle(package_paths: impl Iterator<Item = PathBuf>) -> Result<bool> {
             let longest_pad = package
                 .scripts
                 .iter()
-                .map(|s| s.0.len())
+                .map(|s| s.0.width())
                 .max()
                 .unwrap_or_default();
 


### PR DESCRIPTION
This PR makes the table alignment behavior in `nrr list` use Unicode standards ([`unicode_width::UnicodeWidthStr`](https://docs.rs/unicode-width/latest/unicode_width/trait.UnicodeWidthStr.html#tymethod.width)) instead of bytes ([`String::len`](https://doc.rust-lang.org/std/string/struct.String.html#method.len)).